### PR TITLE
Improve mobile responsiveness for small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -142,7 +142,7 @@ h6 {
         margin-right: 0.5rem;
     }
     .app-header-logo-text {
-        font-size: 1rem;
+        display: none;
     }
 }
 
@@ -297,6 +297,15 @@ h6 {
     border-color: var(--primary-color) !important;
     color: white !important;
     box-shadow: 0 4px 12px hsl(152 28% 40% / 0.2) !important;
+}
+
+@media (max-width: 480px) {
+    .btn-signin-text {
+        display: none;
+    }
+    .btn-signin {
+        padding: 0.5rem !important;
+    }
 }
 
 /* ── Buttons (base) ── */

--- a/src/components/AppHeader.jsx
+++ b/src/components/AppHeader.jsx
@@ -64,7 +64,7 @@ const AppHeader = ({ user }) => {
                 <div className="app-header-logo">
                     <span className="app-header-logo-icon">🥗</span>
                     <span className="app-header-logo-text">
-                        {t('app_title') || "NourishAI"}
+                        {t('app_title') || "Switch-On Diet"}
                     </span>
                 </div>
 
@@ -106,7 +106,7 @@ const AppHeader = ({ user }) => {
                     ) : (
                         <button className="btn-signin" onClick={handleLogin}>
                             <LogIn size={14} />
-                            {t('login_google') || "Sign in"}
+                            <span className="btn-signin-text">{t('login_google') || "Sign in"}</span>
                         </button>
                     )}
                 </div>


### PR DESCRIPTION
## Summary
- Fix horizontal overflow from decorative overlay (`left: -50vw` → `position: fixed`)
- Add responsive container padding: `2rem` → `1rem` on ≤480px
- Fix `body` layout to `display: block` + `overflow-x: hidden`
- Replace broken `md:` inline grid in `RecipeDisplay` with `.recipe-body-grid` CSS class (single column on mobile, `1fr 2fr` on ≥600px)
- Remove fixed `maxWidth: 800px` from `RecipeDisplay` and `maxWidth: 500px` from `DietForm`
- Use `clamp()` for `h1`, `h2`, and subtitle font sizes
- Collapse favorites grid to single column on mobile
- Slide modals up from bottom on mobile (bottom-sheet style)
- Reduce padding on recipe card, form card, and generate buttons on mobile
- Make meta-row (prep/cook/serves) wrap on small screens
- **Header**: hide app name text on ≤480px, show emoji logo only
- **Header**: hide "Sign in" label on ≤480px, show login icon only
- Fix fallback app name from `"NourishAI"` → `"Switch-On Diet"`

## Test plan
- [ ] Open on iPhone SE (375px) or DevTools device toolbar at 375×667
- [ ] Verify header fits cleanly: `🥗 [EN] [→]` logged out, `🥗 [EN] [●]` logged in
- [ ] Verify no horizontal scroll on any screen
- [ ] Verify recipe ingredients/instructions stack vertically on mobile
- [ ] Verify favorites grid is single column on mobile
- [ ] Verify modals slide up from bottom on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)