### PR TITLE
Add account deactivation feature with OAuth revocation

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -40,6 +40,10 @@
         "function": "delete_favorite"
       },
       {
+        "source": "/api/deactivate_account",
+        "function": "deactivate_account"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/functions/main.py
+++ b/functions/main.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import requests
 import google.generativeai as genai
 from firebase_admin import initialize_app, firestore, auth, app_check
 from firebase_functions import https_fn, options
@@ -359,3 +360,93 @@ def delete_favorite(req: https_fn.Request) -> https_fn.Response:
         status=200,
         headers={"Content-Type": "application/json"},
     )
+
+
+# --- Account Deactivation ---
+
+@https_fn.on_request(
+    cors=options.CorsOptions(
+        cors_origins=["*"],
+        cors_methods=["POST", "OPTIONS"],
+    )
+)
+def deactivate_account(req: https_fn.Request) -> https_fn.Response:
+    """
+    Deactivates a user account:
+    1. Revokes Google OAuth token (best-effort)
+    2. Revokes Firebase refresh tokens
+    3. Deletes all Firestore data (favorites subcollection + user doc)
+    4. Deletes the Firebase Auth user record
+    """
+    if req.method == "OPTIONS":
+        return https_fn.Response(status=204)
+
+    if req.method != "POST":
+        return https_fn.Response("Method not allowed", status=405)
+
+    # Auth
+    try:
+        uid, _ = verify_auth(req)
+    except ValueError as e:
+        return https_fn.Response(str(e), status=401)
+    except Exception as e:
+        return https_fn.Response(f"Unauthorized: Invalid token. {str(e)}", status=401)
+
+    # Parse body
+    data = req.get_json() or {}
+    google_access_token = data.get("google_access_token")
+
+    if not google_access_token:
+        return https_fn.Response(
+            json.dumps({"error": "Missing 'google_access_token'"}),
+            status=400,
+            headers={"Content-Type": "application/json"},
+        )
+
+    try:
+        # Step 1: Revoke Google OAuth token (best-effort)
+        try:
+            revoke_resp = requests.post(
+                "https://oauth2.googleapis.com/revoke",
+                params={"token": google_access_token},
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=10,
+            )
+            if revoke_resp.status_code == 200:
+                print(f"Google OAuth token revoked for user {uid}")
+            else:
+                print(f"Google OAuth revocation returned {revoke_resp.status_code} for user {uid}")
+        except Exception as revoke_err:
+            print(f"Google OAuth revocation failed for user {uid}: {revoke_err}")
+
+        # Step 2: Revoke Firebase refresh tokens
+        auth.revoke_refresh_tokens(uid)
+
+        # Step 3: Delete all favorites subcollection documents
+        db = get_db()
+        favorites_ref = db.collection("users").document(uid).collection("favorites")
+        docs = favorites_ref.get()
+        batch = db.batch()
+        for doc in docs:
+            batch.delete(doc.reference)
+        batch.commit()
+
+        # Step 4: Delete user document
+        db.collection("users").document(uid).delete()
+
+        # Step 5: Delete Firebase Auth user record
+        auth.delete_user(uid)
+
+        return https_fn.Response(
+            json.dumps({"message": "Account deactivated successfully"}),
+            status=200,
+            headers={"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        print(f"Account deactivation failed for user {uid}: {e}")
+        return https_fn.Response(
+            json.dumps({"error": f"Failed to deactivate account: {str(e)}"}),
+            status=500,
+            headers={"Content-Type": "application/json"},
+        )

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -2,3 +2,4 @@ firebase-admin>=6.2.0
 firebase-functions>=0.4.0
 google-generativeai>=0.3.2
 flask>=2.0.0
+requests>=2.31.0

--- a/src/App.css
+++ b/src/App.css
@@ -270,6 +270,16 @@ h6 {
     color: #ef4444 !important;
 }
 
+.dropdown-item.deactivate {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.dropdown-item.deactivate:hover {
+    background: #fee2e2 !important;
+    color: #ef4444 !important;
+}
+
 .dropdown-divider {
     height: 1px;
     background: var(--border-color);
@@ -1233,6 +1243,22 @@ button.primary:hover {
 .btn-cancel:hover {
     background: var(--muted-bg) !important;
     color: var(--text-main) !important;
+}
+
+.btn-deactivate-confirm {
+    background: #ef4444 !important;
+    color: white !important;
+    border: none !important;
+    font-weight: 600;
+}
+
+.btn-deactivate-confirm:hover {
+    background: #dc2626 !important;
+}
+
+.btn-deactivate-confirm:disabled {
+    background: #fca5a5 !important;
+    cursor: not-allowed;
 }
 
 /* ═══════════════════════════════════

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,11 +217,19 @@ function App() {
     }
   };
 
+  const handleAccountDeactivated = () => {
+    setUser(null);
+    setRecipe(null);
+    setFavorites([]);
+    setIngredientList([]);
+    setError(null);
+  };
+
   const isFavorited = recipe && favorites.some(f => f.recipe_title === recipe.title);
 
   return (
     <>
-      <AppHeader user={user} />
+      <AppHeader user={user} onAccountDeactivated={handleAccountDeactivated} />
       <div className="container">
         <main>
           {user && (

--- a/src/components/AppHeader.jsx
+++ b/src/components/AppHeader.jsx
@@ -1,12 +1,16 @@
 import { useState, useRef, useEffect } from "react";
-import { Globe, LogIn, Heart, LogOut } from "lucide-react";
+import { Globe, LogIn, Heart, LogOut, UserX } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { signInWithPopup, signOut } from "firebase/auth";
+import { signInWithPopup, signOut, reauthenticateWithPopup } from "firebase/auth";
 import { auth, googleProvider } from "../services/firebase";
+import { deactivateAccountAPI } from "../services/api";
+import DeactivateModal from "./DeactivateModal";
 
-const AppHeader = ({ user }) => {
+const AppHeader = ({ user, onAccountDeactivated }) => {
     const { t, i18n } = useTranslation();
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [showDeactivateModal, setShowDeactivateModal] = useState(false);
+    const [isDeactivating, setIsDeactivating] = useState(false);
     const menuRef = useRef(null);
 
     const handleLogin = async () => {
@@ -23,6 +27,39 @@ const AppHeader = ({ user }) => {
             setIsMenuOpen(false);
         } catch (error) {
             console.error("Logout failed", error);
+        }
+    };
+
+    const handleDeactivateClick = () => {
+        setIsMenuOpen(false);
+        setShowDeactivateModal(true);
+    };
+
+    const handleDeactivateConfirm = async () => {
+        setIsDeactivating(true);
+        try {
+            const result = await reauthenticateWithPopup(auth.currentUser, googleProvider);
+            const googleAccessToken = result.credential?.accessToken;
+
+            if (!googleAccessToken) {
+                throw new Error("Failed to obtain Google access token");
+            }
+
+            await deactivateAccountAPI(googleAccessToken);
+
+            setShowDeactivateModal(false);
+            await signOut(auth);
+
+            if (onAccountDeactivated) {
+                onAccountDeactivated();
+            }
+        } catch (error) {
+            console.error("Deactivation failed:", error);
+            if (error.code !== "auth/popup-closed-by-user") {
+                alert(t('deactivate_error'));
+            }
+        } finally {
+            setIsDeactivating(false);
         }
     };
 
@@ -58,6 +95,7 @@ const AppHeader = ({ user }) => {
     }, []);
 
     return (
+        <>
         <header className="app-header">
             <div className="app-header-container">
                 {/* App name */}
@@ -100,6 +138,11 @@ const AppHeader = ({ user }) => {
                                         <LogOut size={16} />
                                         {t('logout') || "Sign out"}
                                     </button>
+                                    <div className="dropdown-divider"></div>
+                                    <button className="dropdown-item deactivate" onClick={handleDeactivateClick}>
+                                        <UserX size={16} />
+                                        {t('deactivate_account') || "Deactivate Account"}
+                                    </button>
                                 </div>
                             )}
                         </div>
@@ -112,6 +155,15 @@ const AppHeader = ({ user }) => {
                 </div>
             </div>
         </header>
+
+        {showDeactivateModal && (
+            <DeactivateModal
+                onConfirm={handleDeactivateConfirm}
+                onCancel={() => setShowDeactivateModal(false)}
+                isLoading={isDeactivating}
+            />
+        )}
+        </>
     );
 };
 

--- a/src/components/DeactivateModal.jsx
+++ b/src/components/DeactivateModal.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useTranslation } from "react-i18next";
+
+const DeactivateModal = ({ onConfirm, onCancel, isLoading }) => {
+    const { t } = useTranslation();
+
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <div className="modal-header">
+                    <h2>⚠️ {t('deactivate_title')}</h2>
+                </div>
+
+                <div className="modal-body">
+                    <p style={{
+                        fontSize: '0.925rem',
+                        color: 'var(--text-secondary)',
+                        marginBottom: '1.5rem',
+                        lineHeight: '1.6'
+                    }}>
+                        {t('deactivate_warning')}
+                    </p>
+                </div>
+
+                <div className="modal-footer">
+                    <button
+                        className="btn-deactivate-confirm"
+                        onMouseDown={(e) => {
+                            e.preventDefault();
+                            if (!isLoading) onConfirm();
+                        }}
+                        disabled={isLoading}
+                    >
+                        {isLoading ? t('deactivating') : t('deactivate_confirm')}
+                    </button>
+                    <button
+                        className="btn-cancel"
+                        onClick={onCancel}
+                        disabled={isLoading}
+                    >
+                        {t('deactivate_cancel')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default DeactivateModal;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,5 +74,12 @@
     "category_boosters": "Flavour Boosters",
     "copyright": "© {{year}} SoyonLee. All rights reserved.",
     "signin_to_save": "Sign in to save this recipe",
-    "signin_to_share_x": "Sign in to share it on X"
+    "signin_to_share_x": "Sign in to share it on X",
+    "deactivate_account": "Deactivate Account",
+    "deactivate_title": "Deactivate Your Account",
+    "deactivate_warning": "This will permanently delete your account, including all your saved favourite recipes and ingredients. Your Google authorization for this app will also be revoked. This action cannot be undone.",
+    "deactivate_confirm": "Yes, Deactivate My Account",
+    "deactivate_cancel": "Cancel",
+    "deactivate_error": "Failed to deactivate account. Please try again.",
+    "deactivating": "Deactivating..."
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -74,5 +74,12 @@
     "category_boosters": "풍미 더하기",
     "copyright": "© {{year}} 이소연. 모든 권리 보유.",
     "signin_to_save": "레시피를 저장하려면 로그인하세요",
-    "signin_to_share_x": "로그인하여 X에 공유하세요"
+    "signin_to_share_x": "로그인하여 X에 공유하세요",
+    "deactivate_account": "계정 비활성화",
+    "deactivate_title": "계정을 비활성화하시겠습니까?",
+    "deactivate_warning": "이 작업은 저장된 즐겨찾기 레시피와 재료를 포함한 모든 계정 데이터를 영구적으로 삭제합니다. 이 앱에 대한 Google 인증도 해제됩니다. 이 작업은 되돌릴 수 없습니다.",
+    "deactivate_confirm": "네, 계정을 비활성화합니다",
+    "deactivate_cancel": "취소",
+    "deactivate_error": "계정 비활성화에 실패했습니다. 다시 시도해 주세요.",
+    "deactivating": "비활성화 중..."
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -132,3 +132,26 @@ export const deleteFavoriteAPI = async (favoriteId) => {
 
   return response.json();
 };
+
+
+// --- Account Deactivation ---
+
+export const deactivateAccountAPI = async (googleAccessToken) => {
+  const token = await getAuthToken();
+
+  const response = await fetch("/api/deactivate_account", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`
+    },
+    body: JSON.stringify({ google_access_token: googleAccessToken })
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.error || "Failed to deactivate account");
+  }
+
+  return response.json();
+};


### PR DESCRIPTION
## Changes

### Backend (Python/Firebase Functions)
- Added new `/api/deactivate_account` endpoint that:
  - Revokes Google OAuth token
  - Revokes Firebase refresh tokens
  - Deletes all Firestore user data (favorites + user document)
  - Deletes Firebase Auth user record
- Added `requests` dependency for OAuth revocation

### Frontend (React)
- **DeactivateModal**: New confirmation modal component with warning about permanent data deletion
- **AppHeader**: Added "Deactivate Account" option to user menu dropdown
  - Triggers reauthentication with Google OAuth
  - Calls deactivation API with access token
  - Clears local user state on successful deactivation
- **API Service**: New `deactivateAccountAPI()` function to call backend endpoint
- **Styling**: Added CSS classes for deactivate button and modal confirmation button
- **i18n**: Added English and Korean translations for all deactivation UI text
- **App.jsx**: Added callback handler to reset app state after account deactivation